### PR TITLE
Add Devil May Cry-style aerial float to weapons

### DIFF
--- a/pk3/decorate/weapons/0-hwando.dec
+++ b/pk3/decorate/weapons/0-hwando.dec
@@ -170,6 +170,9 @@ ACTOR Kharon : Weapon
         goto Ready2
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         //TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         TNT1 A 0
@@ -510,6 +513,9 @@ ACTOR Kharon : Weapon
         TNT1 A 1
         TNT1 A 0 A_Refire
         TNT1 A 0 A_ClearRefire
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,16,0,0)
         TNT1 A 0 A_PlayWeaponSound("sheathe/swing")
         TNT1 A 0 A_JumpIfInventory("SheatheSwung",1,"AltAttack2")
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"AltAttack1")

--- a/pk3/decorate/weapons/0-ironmaiden.dec
+++ b/pk3/decorate/weapons/0-ironmaiden.dec
@@ -176,6 +176,9 @@ actor "Iron Fist" : Weapon
 
     Fire:
         //TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         IRNF BCD 1
         TNT1 A 0 A_GiveInventory("SlashingLikeAGaijin",1)
@@ -472,6 +475,9 @@ actor "Iron Fist" : Weapon
 
 
     AltFire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,7,0,0)
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"AltFireSequence1")
         IRNF BCD 1
         TNT1 A 0 A_GiveInventory("SlashingLikeAGaijin",1)
@@ -537,6 +543,9 @@ actor "Iron Fist" : Weapon
         IRNB MN 1
         TNT1 A 0 A_AlertMonsters
         TNT1 A 0 A_SetBlend("white",0.25,15)
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,20,0,0)
         TNT1 A 0 A_PlayWeaponSound("holyrocket/fire")
         TNT1 A 0 A_FireCustomMissile("HolyRocket",0,random(-50,50)/500.00,6,0,0,random(-50,50)/500.00)
         TNT1 A 0 A_Recoil(5)

--- a/pk3/decorate/weapons/1-hammer.dec
+++ b/pk3/decorate/weapons/1-hammer.dec
@@ -144,6 +144,9 @@ actor "Kharon + Omen" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPO BCD 1
@@ -411,6 +414,9 @@ actor "Kharon + Omen" : Kharon
 
 
     AltFire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,14,0,0)
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"AltFirePrepare")
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"AltFireGun")
         WEPO BCD 1

--- a/pk3/decorate/weapons/2-pistol.dec
+++ b/pk3/decorate/weapons/2-pistol.dec
@@ -136,6 +136,9 @@ actor "Kharon + Acacia A-22" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPA BCD 1
@@ -411,6 +414,9 @@ actor "Kharon + Acacia A-22" : Kharon
         HPIS A 1 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
         TNT1 A 0 A_JumpIfNoAmmo("Nope")
         //TNT1 A 0 A_GunFlash
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,6,0,0)
         TNT1 A 0 A_Light1
         TNT1 A 0 A_AlertMonsters
         TNT1 A 0 A_PlayWeaponSound("pistol/fire")

--- a/pk3/decorate/weapons/3-shotgun.dec
+++ b/pk3/decorate/weapons/3-shotgun.dec
@@ -143,6 +143,9 @@ actor "Kharon + Testament" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPT BCD 1
@@ -418,6 +421,9 @@ actor "Kharon + Testament" : Kharon
         MSHT A 1 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
         TNT1 A 0 A_JumpIfNoAmmo("nope")
         //TNT1 A 0 A_FireBullets(12,8,16,9,"HuntingPistolPuff", FBF_USEAMMO | FBF_NORANDOM)
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,24,0,0)
         TNT1 A 0 A_FireBullets(0,0,1,0,"BlankPuff", FBF_NORANDOM )
         TNT1 AAAA 0 A_FireCustomMissile("ShotgunBullet1",random(-1000,1000)/100.00,0,0,1,0,random(-800,800)/100.00)
         TNT1 AAAA 0 A_FireCustomMissile("ShotgunBullet1",random(-800,800)/100.00,0,0,1,0,random(-650,650)/100.00)

--- a/pk3/decorate/weapons/4-uzi.dec
+++ b/pk3/decorate/weapons/4-uzi.dec
@@ -130,6 +130,9 @@ actor "Kharon + Sabbath" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPS BCD 1
@@ -405,6 +408,9 @@ actor "Kharon + Sabbath" : Kharon
         SUZI A 1 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
         TNT1 A 0 A_JumpIfNoAmmo("Nope")
         //TNT1 A 0 A_GunFlash
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,1,0,0)
         TNT1 A 0 A_Light1
         TNT1 A 0 A_AlertMonsters
         TNT1 A 0 A_PlayWeaponSound("uzi/fire")

--- a/pk3/decorate/weapons/5-launcher.dec
+++ b/pk3/decorate/weapons/5-launcher.dec
@@ -143,6 +143,9 @@ actor "Kharon + Exodus" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPE BCD 1
@@ -418,6 +421,9 @@ actor "Kharon + Exodus" : Kharon
         GLAG A 1 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
         TNT1 A 0 A_JumpIfNoAmmo("Nope")
         GLAG B 1 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,20,0,0)
         TNT1 A 0 A_Light1
         TNT1 A 0 A_AlertMonsters
         TNT1 A 0 A_PlayWeaponSound("carronade/fire")

--- a/pk3/decorate/weapons/6-boomerang.dec
+++ b/pk3/decorate/weapons/6-boomerang.dec
@@ -157,6 +157,9 @@ actor "Kharon + Legion" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPL BCD 1
@@ -430,6 +433,9 @@ actor "Kharon + Legion" : Kharon
         TNT1 A 0 A_GiveInventory("ShootingLikeABaka",1)
     AltFireGun:
         BMRN A 2 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throw")
         BMRN B 1 A_WeaponReady(WRF_NOFIRE | WRF_NOSWITCH)
         TNT1 A 0 A_FireCustomMissile("ThrownKnife",0,1,0,0,2)
@@ -477,6 +483,9 @@ actor "Kharon + Legion" : Kharon
         goto AltHold
 	FireBoomerang2:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-4,0,0,0,2)
         BMRN H 1 A_FireCustomMissile("ThrownKnife2",4,0,0,0,2)
@@ -484,6 +493,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang3:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-6,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",6,0,0,0,2)
@@ -492,6 +504,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang4:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-8,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-3,0,0,0,2)
@@ -501,6 +516,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang5:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-10,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-5,0,0,0,2)
@@ -511,6 +529,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang6:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-13,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-8,0,0,0,2)
@@ -522,6 +543,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang7:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-15,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-10,0,0,0,2)
@@ -534,6 +558,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang8:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-18,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-13,0,0,0,2)
@@ -547,6 +574,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang9:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-20,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-15,0,0,0,2)
@@ -561,6 +591,9 @@ actor "Kharon + Legion" : Kharon
 		goto FireBoomerangFinish
 	FireBoomerang10:
         BMRN FG 1
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,12,0,0)
         TNT1 A 0 A_PlayWeaponSound("boomerang/throwbunch")
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-23,0,0,0,2)
 	    TNT1 A 0 A_FireCustomMissile("ThrownKnife2",-18,0,0,0,2)

--- a/pk3/decorate/weapons/8-frosthammer.dec
+++ b/pk3/decorate/weapons/8-frosthammer.dec
@@ -281,6 +281,9 @@ actor "Kharon + Frosthammer" : Kharon
 
 
     Fire:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_JumpIfInventory("ShootingLikeABaka",1,"FirePrepare")
         TNT1 A 0 A_JumpIfInventory("SlashingLikeAGaijin",1,"FireSequence1")
         WEPF BCD 1
@@ -553,6 +556,9 @@ actor "Kharon + Frosthammer" : Kharon
         WEPF EFG 1
         TNT1 A 0 A_GiveInventory("ShootingLikeABaka",1)
     AltFireGun:
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,20,0,0)
         TNT1 A 0 A_PlayWeaponSound("frost/fire")
         TNT1 A 0 A_FireBullets(0,0,1,85,"FrosthammerPuff",FBF_NORANDOM)
         TNT1 A 0 Radius_Quake(1,5,0,1,0)
@@ -609,6 +615,9 @@ actor "Kharon + Frosthammer" : Kharon
         TNT1 A 0 A_PlaySoundEx("silence","soundslot5")
         TNT1 A 0 A_TakeInventory("PowerBeamChargeLevel",34)
         TNT1 A 0 A_ClearRefire
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,20,0,0)
         TNT1 A 0 A_PlayWeaponSound("frost/fire")
         TNT1 A 0 A_FireBullets(0,0,1,85,"FrosthammerPuff",FBF_NORANDOM)
         TNT1 A 0 Radius_Quake(1,5,0,1,0)
@@ -682,6 +691,9 @@ actor "Kharon + Frosthammer" : Kharon
         TNT1 A 0 A_TakeInventory("PowerBeamIdle",26)
         TNT1 A 0 A_TakeInventory("PowerBeamCharged",1)
         TNT1 A 0 A_ClearRefire
+        TNT1 A 0 A_CheckFloor(3)
+		TNT1 A 0 A_ChangeVelocity(0,0,momz,3)
+        TNT1 A 0 ThrustThingZ(0,20,0,0)
         TNT1 A 0 A_PlayWeaponSound("frost/firecharged")
         TNT1 A 0 A_ZoomFactor(0.9,ZOOM_INSTANT)
         TNT1 A 0 Radius_Quake(3,16,0,1,0)


### PR DESCRIPTION
- Added aerial float code to all DECORATE weapons
- Attacking while in the air will cause the player to float upward slightly
- It will also stop their XY (LR/FB) momentum
- This allows the player to easily maintain height & position with their target during an air combo
