### PR TITLE
Juggle Physics Tweaks

### DIFF
--- a/pk3/decorate/enemies/arachnotron.dec
+++ b/pk3/decorate/enemies/arachnotron.dec
@@ -114,13 +114,13 @@ ACTOR Priest replaces Arachnotron
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance2",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         PRST IJK 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -142,7 +142,7 @@ ACTOR Priest replaces Arachnotron
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        PRST J 1 ThrustThingZ(0,8,0,0)
+        PRST J 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         PRST J 3 A_Pain

--- a/pk3/decorate/enemies/archvile.dec
+++ b/pk3/decorate/enemies/archvile.dec
@@ -49,13 +49,13 @@ actor WeeabooArchvile : Archvile replaces Archvile
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance2",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         VILE QQQ 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -77,7 +77,7 @@ actor WeeabooArchvile : Archvile replaces Archvile
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        VILE Q 1 ThrustThingZ(0,8,0,0)
+        VILE Q 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         VILE Q 3 A_Pain

--- a/pk3/decorate/enemies/demons.dec
+++ b/pk3/decorate/enemies/demons.dec
@@ -76,13 +76,13 @@ ACTOR WeeabooDemon : Demon replaces Demon
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         SARG IJK 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -103,7 +103,7 @@ ACTOR WeeabooDemon : Demon replaces Demon
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        SARG J 1 ThrustThingZ(0,8,0,0)
+        SARG J 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         SARG J 3 A_Pain
@@ -449,13 +449,13 @@ ACTOR WeeabooClink replaces Spectre
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         CLNK HHH 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -477,7 +477,7 @@ ACTOR WeeabooClink replaces Spectre
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        CLNK H 1 ThrustThingZ(0,8,0,0)
+        CLNK H 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         CLNK H 3 A_Pain

--- a/pk3/decorate/enemies/hellnobles.dec
+++ b/pk3/decorate/enemies/hellnobles.dec
@@ -44,13 +44,13 @@ ACTOR WeeabooHellKnight : HellKnight replaces HellKnight
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         BOS2 IJK 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -71,7 +71,7 @@ ACTOR WeeabooHellKnight : HellKnight replaces HellKnight
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        BOS2 J 1 ThrustThingZ(0,8,0,0)
+        BOS2 J 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         BOS2 J 3 A_Pain
@@ -325,13 +325,13 @@ ACTOR WeeabooBaronOfHell : BaronOfHell replaces BaronOfHell
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance2",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         BOSS IJK 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -352,7 +352,7 @@ ACTOR WeeabooBaronOfHell : BaronOfHell replaces BaronOfHell
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        BOSS J 1 ThrustThingZ(0,8,0,0)
+        BOSS J 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         BOSS J 3 A_Pain

--- a/pk3/decorate/enemies/imp.dec
+++ b/pk3/decorate/enemies/imp.dec
@@ -81,13 +81,13 @@ ACTOR WeeabooImp : DoomImp replaces DoomImp
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         TROO IJK 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TROO L 2 A_CheckFloor("EnemyDrop")
         loop
@@ -102,7 +102,7 @@ ACTOR WeeabooImp : DoomImp replaces DoomImp
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        TROO K 1 ThrustThingZ(0,8,0,0)
+        TROO K 1 ThrustThingZ(0,10,0,0)
         TROO K 3 A_Pain
         Goto EnemyHang2
 

--- a/pk3/decorate/enemies/thebestguy.dec
+++ b/pk3/decorate/enemies/thebestguy.dec
@@ -56,13 +56,13 @@ actor WeeabooRevenant : Revenant replaces Revenant
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance2",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         SKEL MNO 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         TNT1 A 0 A_GiveInventory("LaunchTimerCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchTimerCounter",0,"ForceDrop")
@@ -83,7 +83,7 @@ actor WeeabooRevenant : Revenant replaces Revenant
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        SKEL N 1 ThrustThingZ(0,8,0,0)
+        SKEL N 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         SKEL N 3 A_Pain

--- a/pk3/decorate/enemies/zombies.dec
+++ b/pk3/decorate/enemies/zombies.dec
@@ -94,13 +94,13 @@ ACTOR WeeabooZombie : ZombieMan Replaces ZombieMan
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         POSS HIJ 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        ////TNT1 A 0 A_LowGravity
     EnemyHang2:
         POSS K 2 A_CheckFloor("EnemyDrop")
         loop
@@ -115,7 +115,7 @@ ACTOR WeeabooZombie : ZombieMan Replaces ZombieMan
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        POSS J 1 ThrustThingZ(0,8,0,0)
+        POSS J 1 ThrustThingZ(0,10,0,0)
         POSS J 3 A_Pain
         Goto EnemyHang2
 
@@ -602,13 +602,13 @@ ACTOR WeeabooShotgunner : ShotgunGuy replaces ShotgunGuy
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         SPOS HIJ 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         SPOS K 2 A_CheckFloor("EnemyDrop")
         loop
@@ -623,7 +623,7 @@ ACTOR WeeabooShotgunner : ShotgunGuy replaces ShotgunGuy
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        SPOS J 1 ThrustThingZ(0,8,0,0)
+        SPOS J 1 ThrustThingZ(0,10,0,0)
         SPOS J 3 A_Pain
         Goto EnemyHang2
 
@@ -1062,13 +1062,13 @@ ACTOR WeeabooChaingunner : ChaingunGuy replaces ChaingunGuy
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         CLNC ABC 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         CLNC D 2 A_CheckFloor("EnemyDrop")
         loop
@@ -1083,7 +1083,7 @@ ACTOR WeeabooChaingunner : ChaingunGuy replaces ChaingunGuy
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        CLNC C 1 ThrustThingZ(0,8,0,0)
+        CLNC C 1 ThrustThingZ(0,10,0,0)
         CLNC C 3 A_Pain
         Goto EnemyHang2
 
@@ -1384,13 +1384,13 @@ ACTOR Yakuza replaces WolfensteinSS
         TNT1 A 0 A_GiveInventory("EnemyLaunchedResistance",1)
         TNT1 A 0 A_GiveInventory("EnemyHasBeenLaunched",1)
     EnemyLaunch:
-        TNT1 A 0 A_ChangeVelocity(-4,0,10,3)
+        TNT1 A 0 A_ChangeVelocity(0,0,12,3)
         TNT1 A 0 A_SetInvulnerable
         YKZA HIJ 1
     EnemyHang:      
         TNT1 A 0 A_UnSetInvulnerable
         //TNT1 A 0 A_ChangeVelocity(0,0,0,3)
-        TNT1 A 0 A_LowGravity
+        //TNT1 A 0 A_LowGravity
     EnemyHang2:
         YKZA K 2 A_CheckFloor("EnemyDrop")
         loop
@@ -1408,7 +1408,7 @@ ACTOR Yakuza replaces WolfensteinSS
         TNT1 A 0 A_GiveToTarget("MidCombat",75)
     LaunchedPain:
         TNT1 A 0 A_GiveToTarget("HyperComboCounter",2)
-        YKZA J 1 ThrustThingZ(0,8,0,0)
+        YKZA J 1 ThrustThingZ(0,10,0,0)
         TNT1 A 0 A_GiveInventory("LaunchDamageCounter",1)
         TNT1 A 0 A_JumpIfInventory("LaunchDamageCounter",10,"ForceDrop")
         YKZA J 3 A_Pain


### PR DESCRIPTION
- Modified enemy launch states to use standard gravity for better height control
- Currently set to launch as high as a player jump
- Removed front-back component from launcher thrust
- Previously, enemies would launch up and back relative to their facing rather than the player
- Disabled for more consistent behaviour
