### PR TITLE
Add ds_dropammo CVar to control zombie ammo drops

### DIFF
--- a/pk3/CVARINFO.txt
+++ b/pk3/CVARINFO.txt
@@ -9,6 +9,7 @@ server int ds_nospecials        = 0;
 server int ds_infinitesouls     = 0;
 server int ds_arrogantweapons   = 0;
 server int ds_gunsouls          = 0;
+server int ds_dropammo          = 0;
 
 // Clientside cvars
 user int ds_cl_nomusic          = 0;

--- a/pk3/DECORATE.dec
+++ b/pk3/DECORATE.dec
@@ -142,6 +142,7 @@ const int WEEB_DEC_FROSTCHECK  = 23;
 const int WEEB_DEC_COOKIEQUOTE = 24;
 const int WEEB_DEC_SLOWDOWN    = 25;
 const int WEEB_DEC_GUNSOULS    = 26;
+const int WEEB_DEC_DROPAMMO    = 27;
 
 const int WEEB_DEC_GETMESSAGES   = 0;
 const int WEEB_DEC_CHANGEMUS     = 1;

--- a/pk3/acs/weeaboo.c
+++ b/pk3/acs/weeaboo.c
@@ -76,6 +76,10 @@ script WEEB_OPEN OPEN
         if (!GetCvar("ds_gunsouls"))
             { ConsoleCommand("set ds_gunsouls 0");
               ConsoleCommand("archivecvar ds_gunsouls 0"); }
+			  
+        if (!GetCvar("ds_dropammo"))
+            { ConsoleCommand("set ds_dropammo 0");
+              ConsoleCommand("archivecvar ds_dropammo 0"); }
     }
 }
 
@@ -385,6 +389,10 @@ int i;
 
     case WEEB_DEC_GUNSOULS:
         SetResultValue(GetCVar("ds_gunsouls"));
+        break;
+		
+    case WEEB_DEC_DROPAMMO:
+        SetResultValue( GetCVar("ds_dropammo") );
         break;
     }
 }

--- a/pk3/acs/weeb_const.h
+++ b/pk3/acs/weeb_const.h
@@ -75,6 +75,7 @@
 #define WEEB_DEC_COOKIEQUOTE  24
 #define WEEB_DEC_SLOWDOWN     25
 #define WEEB_DEC_GUNSOULS     26
+#define WEEB_DEC_DROPAMMO     27
 
 #define WEEB_DEC_GETMESSAGES    0
 #define WEEB_DEC_CHANGEMUS      1

--- a/pk3/decorate/ammo.dec
+++ b/pk3/decorate/ammo.dec
@@ -25,6 +25,47 @@ actor HammerAmmoSmall : HammerCharge 30241
     Scale 0.35
 }
 
+actor MaybeClipDrop
+{
+	States
+	{
+		Spawn:
+			TNT1 A 0
+			TNT1 A 0 A_JumpIf( ACS_ExecuteWithResult(267,WEEB_DEC_DROPAMMO) == 0, 2 )
+			TNT1 A 0 A_SpawnItemEx ( "WeebClip" )
+			TNT1 A 0
+			Stop
+	}
+}
+
+actor MaybeBigClipDrop
+{
+	States
+	{
+		Spawn:
+			TNT1 A 0
+			TNT1 A 0 A_JumpIf( ACS_ExecuteWithResult(267,WEEB_DEC_DROPAMMO) == 0, 3 )
+			TNT1 A 0 A_SpawnItemEx ( "WeebClip" )
+			TNT1 A 0 A_SpawnItemEx ( "WeebClip" )
+			TNT1 A 0
+			Stop
+	}
+}
+
+actor MaybeShellDrop
+{
+	States
+	{
+		Spawn:
+			TNT1 A 0
+			TNT1 A 0 A_JumpIf( ACS_ExecuteWithResult(267,WEEB_DEC_DROPAMMO) == 0, 3 )
+			TNT1 A 0 A_SpawnItemEx ( "WeebShell" )
+			TNT1 A 0 A_SpawnItemEx ( "WeebShell" )
+			TNT1 A 0
+			Stop
+	}
+}
+
 actor WeebClip : Ammo replaces Clip
 {
     Inventory.PickupMessage "Picked up a few bullets."

--- a/pk3/decorate/enemies/zombies.dec
+++ b/pk3/decorate/enemies/zombies.dec
@@ -30,7 +30,7 @@ ACTOR WeeabooZombie : ZombieMan Replaces ZombieMan
     PainSound "zombie/pain"
     ActiveSound "zombie/idle"
     DeathSound "zombie/death"
-    DropItem "ShitAll"
+    DropItem "MaybeClipDrop"
     States
     {
     See: // Apparently changing their speed gets them blocked on each other?
@@ -558,7 +558,7 @@ ACTOR WeeabooShotgunner : ShotgunGuy replaces ShotgunGuy
     PainSound "zombie/pain"
     ActiveSound "zombie/idle"
     DeathSound "zombie/death"
-    DropItem "ShitAll"
+    DropItem "MaybeShellDrop"
     States
     {
     See:
@@ -1052,7 +1052,7 @@ ACTOR WeeabooChaingunner : ChaingunGuy replaces ChaingunGuy
     PainSound "zombie/pain"
     ActiveSound "zombie/idle"
     DeathSound "zombie/death"
-    DropItem "ShitAll"
+    DropItem "MaybeBigClipDrop"
     States
     {
     See:


### PR DESCRIPTION
- Added MaybeClipDrop, MaybeBigClipDrop and MaybeShellDrop
- Checks ds_dropammo and spawns the correct amount of ammo if true
- Improves gun balance when using level mods that eschew ammo for zombies

This branch and the doomhealth branch don't play nice with git merge, there's something about the constant definition files that gnu patch doesn't seem to like. So if you decide to take them both, I'll have to rebase and fix merge errors before the latter one will apply cleanly.
