### PR TITLE
Linux build

### DIFF
--- a/makefile.linux
+++ b/makefile.linux
@@ -16,7 +16,7 @@ help:
 
 pk3:
 	@echo -n "Building ${NAME}.pk3 ......"
-	@cd pk3 && zip ../${NAME}.pk3 *.* *
+	@cd pk3 && 7z a -tzip ../${NAME}.pk3 *
 	@echo "done"
 
 pk7:
@@ -37,7 +37,7 @@ compile:
 
 ssh-pk3:
 	@echo -n "Building ${SSH_NAME}.pk3 ......"
-	@cd ssh && zip ../${SSH_NAME}.pk3 *.* *
+	@cd ssh && 7z a -tzip ../${SSH_NAME}.pk3 *.* *
 	@echo "done"
 
 ssh-pk7:

--- a/makefile.linux
+++ b/makefile.linux
@@ -1,5 +1,6 @@
 # a Unix based makefile
 NAME=te13-DemonSteele
+SSH_NAME=${NAME}-ssh
 SRC=pk3/acs
 OBJ=pk3/acs
 .PHONY: help pk3 pk7 clean
@@ -12,24 +13,32 @@ help:
 	@echo "  compile - equivalent to the commands in _compile.bat (assumes that acc is on the path)!"
 
 pk3:
-	@cd pk3
-	@echo -n "Building pk3 archive...."
-	@zip ../${NAME}.pk3 *.* *
-	@echo "Done"
+	@echo -n "Building ${NAME}.pk3 ......"
+	@cd pk3 && zip ../${NAME}.pk3 *.* *
+	@echo "done"
 
 pk7:
-	@cd pk3
-	@echo -n "Building pk7 archive....."
-	@7z ../${NAME}.pk7 *.* *
-	@echo "Done"
+	@echo -n "Building ${NAME}.pk7......"
+	@cd pk3 && 7z a ../${NAME}.pk7 *
+	@echo "done"
 
 clean:
 	@echo -n "Removing archives....."
-	@rm -f ${NAME}.pk7 ${NAME}.pk3
-	@echo "Done"
+	@rm -f ${NAME}.pk7 ${NAME}.pk3 ${SSH_NAME}.pk7 ${SSH_NAME}.pk3
+	@echo "done"
 
 # assume that acc is on the path
 compile:
 	@echo -n "Compiling Weeaboo"
 	@acc ${SRC}/weeaboo.c ${OBJ}/weeaboo.o
-	@echo "DONE"
+	@echo "done"
+
+ssh-pk3:
+	@echo -n "Building ${SSH_NAME}.pk3 ......"
+	@cd ssh && zip ../${SSH_NAME}.pk3 *.* *
+	@echo "done"
+
+ssh-pk7:
+	@echo -n "Building ${SSH_NAME}.pk7......"
+	@cd ssh && 7z a ../${SSH_NAME}.pk7 *
+	@echo "done"

--- a/makefile.linux
+++ b/makefile.linux
@@ -3,7 +3,7 @@ NAME=te13-DemonSteele
 SSH_NAME=${NAME}-ssh
 SRC=pk3/acs
 OBJ=pk3/acs
-.PHONY: help pk3 pk7 clean
+.PHONY: help pk3 pk7 clean ssh-pk3 ssh-pk7
 
 help:
 	@echo "Available options:"
@@ -11,6 +11,8 @@ help:
 	@echo "  pk3     - builds a pk3 archive of the target sources"
 	@echo "  pk7     - builds a pk7 archive of the target sources"
 	@echo "  compile - equivalent to the commands in _compile.bat (assumes that acc is on the path)!"
+	@echo "  ssh-pk3 - Build a pk3 archive of the ssh folder"
+	@echo "  ssh-pk7 - Build a pk7 archive of the ssh folder"
 
 pk3:
 	@echo -n "Building ${NAME}.pk3 ......"

--- a/makefile.linux
+++ b/makefile.linux
@@ -1,0 +1,35 @@
+# a Unix based makefile
+NAME=te13-DemonSteele
+SRC=pk3/acs
+OBJ=pk3/acs
+.PHONY: help pk3 pk7 clean
+
+help:
+	@echo "Available options:"
+	@echo "  help    - prints this dialog and exits"
+	@echo "  pk3     - builds a pk3 archive of the target sources"
+	@echo "  pk7     - builds a pk7 archive of the target sources"
+	@echo "  compile - equivalent to the commands in _compile.bat (assumes that acc is on the path)!"
+
+pk3:
+	@cd pk3
+	@echo -n "Building pk3 archive...."
+	@zip ../${NAME}.pk3 *.* *
+	@echo "Done"
+
+pk7:
+	@cd pk3
+	@echo -n "Building pk7 archive....."
+	@7z ../${NAME}.pk7 *.* *
+	@echo "Done"
+
+clean:
+	@echo -n "Removing archives....."
+	@rm -f ${NAME}.pk7 ${NAME}.pk3
+	@echo "Done"
+
+# assume that acc is on the path
+compile:
+	@echo -n "Compiling Weeaboo"
+	@acc ${SRC}/weeaboo.c ${OBJ}/weeaboo.o
+	@echo "DONE"


### PR DESCRIPTION
Added the ability to build the mod in linux through the use of make. A linux user has to do 

make -f makefile.linux 

to bring up the help and choose an option (usually pk3 or pk7).

It does require that the user have 7z already installed via their package manager (thus it doesn't
need to be shipped with the repo).
